### PR TITLE
[FIX] Small fixing in the test references

### DIFF
--- a/src/Tests/Mvp24Hours.Application.SQLServer.Test/Setup/Startup.cs
+++ b/src/Tests/Mvp24Hours.Application.SQLServer.Test/Setup/Startup.cs
@@ -9,7 +9,6 @@ using Mvp24Hours.Application.SQLServer.Test.Support.Data;
 using Mvp24Hours.Application.SQLServer.Test.Support.Entities;
 using Mvp24Hours.Application.SQLServer.Test.Support.Entities.BasicLogs;
 using Mvp24Hours.Application.SQLServer.Test.Support.Entities.Basics;
-using Mvp24Hours.Application.SQLServer.Test.Support.Entities.Logs;
 using Mvp24Hours.Application.SQLServer.Test.Support.Enums;
 using Mvp24Hours.Application.SQLServer.Test.Support.Services;
 using Mvp24Hours.Core.Helpers;
@@ -195,21 +194,21 @@ namespace Mvp24Hours.Application.SQLServer.Test.Setup
         private static void LoadDataLog(IServiceProvider serviceProvider)
         {
             var service = serviceProvider.GetService<CustomerLogService>();
-            List<CustomerLog> customers = [];
+            List<CustomerBasicLog> customers = [];
             for (int i = 1; i <= 10; i++)
             {
-                var customer = new CustomerLog
+                var customer = new CustomerBasicLog
                 {
                     Name = $"Test {i}",
                     Active = true
                 };
-                customer.Contacts.Add(new ContactLog
+                customer.Contacts.Add(new ContactBasicLog
                 {
                     Description = $"202-555-014{i}",
                     Type = ContactType.CellPhone,
                     Active = true
                 });
-                customer.Contacts.Add(new ContactLog
+                customer.Contacts.Add(new ContactBasicLog
                 {
                     Description = $"test{i}@sample.com",
                     Type = ContactType.Email,

--- a/src/Tests/Mvp24Hours.Application.SQLServer.Test/Support/Data/DataContext.cs
+++ b/src/Tests/Mvp24Hours.Application.SQLServer.Test/Support/Data/DataContext.cs
@@ -7,7 +7,6 @@ using Microsoft.EntityFrameworkCore;
 using Mvp24Hours.Application.SQLServer.Test.Support.Entities;
 using Mvp24Hours.Application.SQLServer.Test.Support.Entities.BasicLogs;
 using Mvp24Hours.Application.SQLServer.Test.Support.Entities.Basics;
-using Mvp24Hours.Application.SQLServer.Test.Support.Entities.Logs;
 using Mvp24Hours.Infrastructure.Data.EFCore;
 
 namespace Mvp24Hours.Application.SQLServer.Test.Support.Data
@@ -40,8 +39,8 @@ namespace Mvp24Hours.Application.SQLServer.Test.Support.Data
         public virtual DbSet<CustomerBasic> CustomerBasic { get; set; }
         public virtual DbSet<ContactBasic> ContactBasic { get; set; }
 
-        public virtual DbSet<CustomerLog> CustomerLog { get; set; }
-        public virtual DbSet<ContactLog> ContactLog { get; set; }
+        public virtual DbSet<CustomerBasicLog> CustomerLog { get; set; }
+        public virtual DbSet<ContactBasicLog> ContactLog { get; set; }
 
         public virtual DbSet<CustomerBasicLog> CustomerBasicLog { get; set; }
         public virtual DbSet<ContactBasicLog> ContactBasicLog { get; set; }

--- a/src/Tests/Mvp24Hours.Application.SQLServer.Test/Support/Services/CustomerLogService.cs
+++ b/src/Tests/Mvp24Hours.Application.SQLServer.Test/Support/Services/CustomerLogService.cs
@@ -4,19 +4,19 @@
 // Reproduction or sharing is free! Contribute to a better world!
 //=====================================================================================
 using Mvp24Hours.Application.Logic;
-using Mvp24Hours.Application.SQLServer.Test.Support.Entities.Logs;
+using Mvp24Hours.Application.SQLServer.Test.Support.Entities.BasicLogs;
 using Mvp24Hours.Core.Contract.Data;
 using Mvp24Hours.Core.ValueObjects.Logic;
 using System.Collections.Generic;
 
 namespace Mvp24Hours.Application.SQLServer.Test.Support.Services
 {
-    public class CustomerLogService(IUnitOfWork unitOfWork) : RepositoryService<CustomerLog, IUnitOfWork>(unitOfWork)
+    public class CustomerLogService(IUnitOfWork unitOfWork) : RepositoryService<CustomerBasicLog, IUnitOfWork>(unitOfWork)
     {
 
         // custom methods here
 
-        public IList<CustomerLog> GetWithContacts()
+        public IList<CustomerBasicLog> GetWithContacts()
         {
             var paging = new PagingCriteria(3, 0);
 
@@ -29,7 +29,7 @@ namespace Mvp24Hours.Application.SQLServer.Test.Support.Services
             return customers;
         }
 
-        public IList<CustomerLog> GetWithPagedContacts()
+        public IList<CustomerBasicLog> GetWithPagedContacts()
         {
             var paging = new PagingCriteria(3, 0);
 

--- a/src/Tests/Mvp24Hours.Application.SQLServer.Test/Test1LogService.cs
+++ b/src/Tests/Mvp24Hours.Application.SQLServer.Test/Test1LogService.cs
@@ -6,7 +6,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using Mvp24Hours.Application.SQLServer.Test.Setup;
 using Mvp24Hours.Application.SQLServer.Test.Support.Entities;
-using Mvp24Hours.Application.SQLServer.Test.Support.Entities.Logs;
+using Mvp24Hours.Application.SQLServer.Test.Support.Entities.BasicLogs;
 using Mvp24Hours.Application.SQLServer.Test.Support.Services;
 using Mvp24Hours.Core.ValueObjects.Logic;
 using Mvp24Hours.Extensions;
@@ -43,7 +43,7 @@ namespace Mvp24Hours.Application.SQLServer.Test
             // arrange
             var service = serviceProvider.GetService<CustomerLogService>();
             // act
-            var customer = new CustomerLog
+            var customer = new CustomerBasicLog
             {
                 Name = "Test 1",
                 Active = true
@@ -59,7 +59,7 @@ namespace Mvp24Hours.Application.SQLServer.Test
             // arrange
             var service = serviceProvider.GetService<CustomerLogService>();
             // act
-            var customer = new CustomerLog
+            var customer = new CustomerBasicLog
             {
                 Name = "Test 1",
                 Active = true
@@ -79,7 +79,7 @@ namespace Mvp24Hours.Application.SQLServer.Test
             // arrange
             var service = serviceProvider.GetService<CustomerLogService>();
             // act
-            var customer = new CustomerLog
+            var customer = new CustomerBasicLog
             {
                 Name = "Test 1",
                 Active = true


### PR DESCRIPTION
Some references were causing tests to break in the `Mvp24Hours.Application.SQLServer.Test` project. 

- References `using` the namespace `Mvp24Hours.Application.SQLServer.Test.Support.Entities.Logs` were giving an error, because this namespace no longer exists. I understand that it has been replaced by the name `Mvp24Hours.Application.SQLServer.Test.Support.Entities.BasicLogs`.
- References to the `CustomerLog` and `ContactLog` objects with an error, because the objects no longer exist. They have been replaced by the `CustomerBasicLog` and `ContactBasicLog` objects. 