### PR TITLE
[FEAT] Adding new method AddError in IPipelineMessage

### DIFF
--- a/src/Mvp24Hours.Infrastructure.Pipe/Extensions/PipelineMessageExtensions.cs
+++ b/src/Mvp24Hours.Infrastructure.Pipe/Extensions/PipelineMessageExtensions.cs
@@ -10,6 +10,7 @@ using Mvp24Hours.Core.ValueObjects.Logic;
 using Mvp24Hours.Helpers;
 using Mvp24Hours.Infrastructure.Pipe;
 using System.Collections.Generic;
+using System.ServiceModel.Channels;
 
 namespace Mvp24Hours.Extensions
 {
@@ -148,5 +149,13 @@ namespace Mvp24Hours.Extensions
             return messages;
         }
 
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="errorMessage"></param>
+        public static void AddError(this IPipelineMessage pipelineMessage, string errorMessage)
+        {
+            pipelineMessage.Messages.Add(errorMessage.ToMessageResult(MessageType.Error));
+        }
     }
 }

--- a/src/Tests/Mvp24Hours.Application.Pipe.Test/PipelineTest.cs
+++ b/src/Tests/Mvp24Hours.Application.Pipe.Test/PipelineTest.cs
@@ -4,6 +4,7 @@
 // Reproduction or sharing is free! Contribute to a better world!
 //=====================================================================================
 using Mvp24Hours.Application.Pipe.Test.Operations;
+using Mvp24Hours.Core.Enums;
 using Mvp24Hours.Core.Enums.Infrastructure;
 using Mvp24Hours.Extensions;
 using Mvp24Hours.Infrastructure.Pipe;
@@ -554,6 +555,28 @@ namespace Mvp24Hours.Application.Pipe.Test
 
             // assert
             Assert.Equal(1, result);
+        }
+
+        [Fact, Priority(12)]
+        public void PipelineMessageWithError()
+        {
+            // arrange
+            Pipeline pipeline = new();
+
+            // act
+            pipeline.Add(input =>
+            {
+                input.AddError("minha mensagem de erro");
+            }); 
+
+            // operations
+            pipeline.Execute();
+            var pipelineMessage = pipeline.GetMessage();
+
+            // assert
+            Assert.True(pipelineMessage.IsFaulty);
+            Assert.Single(pipelineMessage.Messages);
+            Assert.Equal(MessageType.Error, pipelineMessage.Messages[0].Type);
         }
     }
 }

--- a/src/Tests/Mvp24Hours.Application.SQLServer.Test/Setup/Startup.cs
+++ b/src/Tests/Mvp24Hours.Application.SQLServer.Test/Setup/Startup.cs
@@ -9,7 +9,6 @@ using Mvp24Hours.Application.SQLServer.Test.Support.Data;
 using Mvp24Hours.Application.SQLServer.Test.Support.Entities;
 using Mvp24Hours.Application.SQLServer.Test.Support.Entities.BasicLogs;
 using Mvp24Hours.Application.SQLServer.Test.Support.Entities.Basics;
-using Mvp24Hours.Application.SQLServer.Test.Support.Entities.Logs;
 using Mvp24Hours.Application.SQLServer.Test.Support.Enums;
 using Mvp24Hours.Application.SQLServer.Test.Support.Services;
 using Mvp24Hours.Core.Helpers;
@@ -195,21 +194,21 @@ namespace Mvp24Hours.Application.SQLServer.Test.Setup
         private static void LoadDataLog(IServiceProvider serviceProvider)
         {
             var service = serviceProvider.GetService<CustomerLogService>();
-            List<CustomerLog> customers = [];
+            List<CustomerBasicLog> customers = [];
             for (int i = 1; i <= 10; i++)
             {
-                var customer = new CustomerLog
+                var customer = new CustomerBasicLog
                 {
                     Name = $"Test {i}",
                     Active = true
                 };
-                customer.Contacts.Add(new ContactLog
+                customer.Contacts.Add(new ContactBasicLog
                 {
                     Description = $"202-555-014{i}",
                     Type = ContactType.CellPhone,
                     Active = true
                 });
-                customer.Contacts.Add(new ContactLog
+                customer.Contacts.Add(new ContactBasicLog
                 {
                     Description = $"test{i}@sample.com",
                     Type = ContactType.Email,

--- a/src/Tests/Mvp24Hours.Application.SQLServer.Test/Support/Data/DataContext.cs
+++ b/src/Tests/Mvp24Hours.Application.SQLServer.Test/Support/Data/DataContext.cs
@@ -7,7 +7,6 @@ using Microsoft.EntityFrameworkCore;
 using Mvp24Hours.Application.SQLServer.Test.Support.Entities;
 using Mvp24Hours.Application.SQLServer.Test.Support.Entities.BasicLogs;
 using Mvp24Hours.Application.SQLServer.Test.Support.Entities.Basics;
-using Mvp24Hours.Application.SQLServer.Test.Support.Entities.Logs;
 using Mvp24Hours.Infrastructure.Data.EFCore;
 
 namespace Mvp24Hours.Application.SQLServer.Test.Support.Data
@@ -40,8 +39,8 @@ namespace Mvp24Hours.Application.SQLServer.Test.Support.Data
         public virtual DbSet<CustomerBasic> CustomerBasic { get; set; }
         public virtual DbSet<ContactBasic> ContactBasic { get; set; }
 
-        public virtual DbSet<CustomerLog> CustomerLog { get; set; }
-        public virtual DbSet<ContactLog> ContactLog { get; set; }
+        public virtual DbSet<CustomerBasicLog> CustomerLog { get; set; }
+        public virtual DbSet<ContactBasicLog> ContactLog { get; set; }
 
         public virtual DbSet<CustomerBasicLog> CustomerBasicLog { get; set; }
         public virtual DbSet<ContactBasicLog> ContactBasicLog { get; set; }

--- a/src/Tests/Mvp24Hours.Application.SQLServer.Test/Support/Services/CustomerLogService.cs
+++ b/src/Tests/Mvp24Hours.Application.SQLServer.Test/Support/Services/CustomerLogService.cs
@@ -4,19 +4,19 @@
 // Reproduction or sharing is free! Contribute to a better world!
 //=====================================================================================
 using Mvp24Hours.Application.Logic;
-using Mvp24Hours.Application.SQLServer.Test.Support.Entities.Logs;
+using Mvp24Hours.Application.SQLServer.Test.Support.Entities.BasicLogs;
 using Mvp24Hours.Core.Contract.Data;
 using Mvp24Hours.Core.ValueObjects.Logic;
 using System.Collections.Generic;
 
 namespace Mvp24Hours.Application.SQLServer.Test.Support.Services
 {
-    public class CustomerLogService(IUnitOfWork unitOfWork) : RepositoryService<CustomerLog, IUnitOfWork>(unitOfWork)
+    public class CustomerLogService(IUnitOfWork unitOfWork) : RepositoryService<CustomerBasicLog, IUnitOfWork>(unitOfWork)
     {
 
         // custom methods here
 
-        public IList<CustomerLog> GetWithContacts()
+        public IList<CustomerBasicLog> GetWithContacts()
         {
             var paging = new PagingCriteria(3, 0);
 
@@ -29,7 +29,7 @@ namespace Mvp24Hours.Application.SQLServer.Test.Support.Services
             return customers;
         }
 
-        public IList<CustomerLog> GetWithPagedContacts()
+        public IList<CustomerBasicLog> GetWithPagedContacts()
         {
             var paging = new PagingCriteria(3, 0);
 

--- a/src/Tests/Mvp24Hours.Application.SQLServer.Test/Test1LogService.cs
+++ b/src/Tests/Mvp24Hours.Application.SQLServer.Test/Test1LogService.cs
@@ -6,7 +6,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using Mvp24Hours.Application.SQLServer.Test.Setup;
 using Mvp24Hours.Application.SQLServer.Test.Support.Entities;
-using Mvp24Hours.Application.SQLServer.Test.Support.Entities.Logs;
+using Mvp24Hours.Application.SQLServer.Test.Support.Entities.BasicLogs;
 using Mvp24Hours.Application.SQLServer.Test.Support.Services;
 using Mvp24Hours.Core.ValueObjects.Logic;
 using Mvp24Hours.Extensions;
@@ -43,7 +43,7 @@ namespace Mvp24Hours.Application.SQLServer.Test
             // arrange
             var service = serviceProvider.GetService<CustomerLogService>();
             // act
-            var customer = new CustomerLog
+            var customer = new CustomerBasicLog
             {
                 Name = "Test 1",
                 Active = true
@@ -59,7 +59,7 @@ namespace Mvp24Hours.Application.SQLServer.Test
             // arrange
             var service = serviceProvider.GetService<CustomerLogService>();
             // act
-            var customer = new CustomerLog
+            var customer = new CustomerBasicLog
             {
                 Name = "Test 1",
                 Active = true
@@ -79,7 +79,7 @@ namespace Mvp24Hours.Application.SQLServer.Test
             // arrange
             var service = serviceProvider.GetService<CustomerLogService>();
             // act
-            var customer = new CustomerLog
+            var customer = new CustomerBasicLog
             {
                 Name = "Test 1",
                 Active = true


### PR DESCRIPTION
As was discussed in this issue Closes #2 , this PR add a new method called AddError for the IPipelineMessage.

Now, inside any step of pipeline, you can use the method below:
```
input.AddError("my error message"); 
```

This method automatically will:

- Mark the PipelineMessage as Faulty
- Add a MessageResult with type Error in the Messages property.