### PR TITLE
[FEAT] Adding support to cronjobs

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -8,6 +8,7 @@
 * [Mapping](en-us/mapping.md)
 * [Logging](en-us/logging.md)
 * [Telemetry](en-us/telemetry.md)
+* [CronJob](en-us/cronjob.md)
 * Patterns
 * * [Entity](en-us/database/use-entity.md)
 * * [Database Context](en-us/database/use-context.md)

--- a/docs/en-us/cronjob.md
+++ b/docs/en-us/cronjob.md
@@ -1,0 +1,31 @@
+# CronJob
+Solution created to enable tasks to be scheduled to run in the background. To schedule, you must use the UNIX `cron` format, informing the periodicity of the execution.
+
+## CronJob Service
+```csharp
+class MyCronJob : CronJobService<MyCronJob>
+{
+    public MyCronJob(
+        IScheduleConfig<CustomerCronJob> config, 
+        IHostApplicationLifetime hostApplication, 
+        IServiceProvider serviceProvider) : base(config, hostApplication, serviceProvider)
+    { }
+
+    public override Task DoWork(CancellationToken cancellationToken)
+    {
+       //put the logic here
+    }
+}
+```
+
+## Settings
+```csharp
+...
+services.AddCronJob<MyCronJob>(options => 
+{
+    TimeZoneInfo = TimeZoneInfo.Utc,
+    CronExpression = "* * * * *"
+})
+```
+
+In the exemple above, the Job will be executed `every minute`. 

--- a/docs/pt-br/cronjob.md
+++ b/docs/pt-br/cronjob.md
@@ -1,0 +1,31 @@
+# CronJob
+Solução criada para habilitar tarefas para serem executadas em background. Para configurar o agendamento, você deve utilizar o padrão UNIX `cron` informando o periodo da execução.
+
+## CronJob Service
+```csharp
+class MyCronJob : CronJobService<MyCronJob>
+{
+    public MyCronJob(
+        IScheduleConfig<CustomerCronJob> config, 
+        IHostApplicationLifetime hostApplication, 
+        IServiceProvider serviceProvider) : base(config, hostApplication, serviceProvider)
+    { }
+
+    public override Task DoWork(CancellationToken cancellationToken)
+    {
+       //Coloque sua lógica aqui
+    }
+}
+```
+
+## Configurações
+```csharp
+...
+services.AddCronJob<MyCronJob>(options => 
+{
+    TimeZoneInfo = TimeZoneInfo.Utc,
+    CronExpression = "* * * * *"
+})
+```
+
+No exemplo acima, o serviço será executada `a todo minuto`.

--- a/src/Mvp24Hours.Application.CronJob.Test/CronJobTest.cs
+++ b/src/Mvp24Hours.Application.CronJob.Test/CronJobTest.cs
@@ -1,0 +1,45 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Moq;
+using Mvp24Hours.Application.CronJob.Test.Support.ConJobs;
+using Mvp24Hours.Application.CronJob.Test.Support.Services;
+using Mvp24Hours.Infrastructure.CronJob;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Mvp24Hours.Application.CronJob.Test
+{
+    public class CronJobTest
+    {
+        #region [ Fields ]
+        #endregion
+
+        #region [ Configure ]
+        #endregion
+
+        [Fact]
+        public async Task CronJobWithCorrectScheduler()
+        {
+            var timerService = new TimerService();
+            var services = new ServiceCollection();
+            services.AddSingleton(timerService);
+            var serviceProvider = services.BuildServiceProvider();
+            var scheduleConfig = new ScheduleConfig<CustomerCronJob>()
+            {
+                TimeZoneInfo = TimeZoneInfo.Utc,
+                CronExpression = "* * * * *"
+            };
+            var hostApplicationLifetimeMock = new Mock<IHostApplicationLifetime>();
+            var cronjobHostedService = new CustomerCronJob(scheduleConfig, hostApplicationLifetimeMock.Object, serviceProvider);
+
+            var cts = new CancellationTokenSource();
+            timerService.Start();
+            await cronjobHostedService.StartAsync(cts.Token);
+            await Task.Delay(120 * 1000); //2 minutes
+            await cronjobHostedService.StopAsync(cts.Token);
+
+            Assert.Equal(2, timerService.Counters.Count);
+        }
+    }
+}

--- a/src/Mvp24Hours.Application.CronJob.Test/GlobalUsings.cs
+++ b/src/Mvp24Hours.Application.CronJob.Test/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/src/Mvp24Hours.Application.CronJob.Test/Mvp24Hours.Application.CronJob.Test.csproj
+++ b/src/Mvp24Hours.Application.CronJob.Test/Mvp24Hours.Application.CronJob.Test.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="xunit" Version="2.6.6" />
+    <PackageReference Include="Xunit.Priority" Version="1.1.6" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Mvp24Hours.Core\Mvp24Hours.Core.csproj" />
+    <ProjectReference Include="..\Mvp24Hours.Infrastructure.CronJob\Mvp24Hours.Infrastructure.CronJob.csproj" />
+    <ProjectReference Include="..\Mvp24Hours.Infrastructure\Mvp24Hours.Infrastructure.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Mvp24Hours.Application.CronJob.Test/Support/ConJobs/CustomerCronJob.cs
+++ b/src/Mvp24Hours.Application.CronJob.Test/Support/ConJobs/CustomerCronJob.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Mvp24Hours.Application.CronJob.Test.Support.Services;
+using Mvp24Hours.Infrastructure.CronJob.Interfaces;
+using Mvp24Hours.Infrastructure.CronJob.Services;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Mvp24Hours.Application.CronJob.Test.Support.ConJobs
+{
+    public class CustomerCronJob : CronJobService<CustomerCronJob>
+    {
+        public CustomerCronJob(
+            IScheduleConfig<CustomerCronJob> config, 
+            IHostApplicationLifetime hostApplication, 
+            IServiceProvider serviceProvider) : base(config, hostApplication, serviceProvider)
+        { }
+
+        public override Task DoWork(CancellationToken cancellationToken)
+        {
+            Console.WriteLine("Cronjob começou a contar");
+            var timerService = _serviceProvider.GetService<TimerService>();
+            timerService.CountTime(); 
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Mvp24Hours.Application.CronJob.Test/Support/Services/TimerService.cs
+++ b/src/Mvp24Hours.Application.CronJob.Test/Support/Services/TimerService.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Mvp24Hours.Application.CronJob.Test.Support.Services
+{
+    public class TimerService
+    {
+        public DateTime StartTime { get; set; }
+        public int CurrentCounter { get; set; } = 0; 
+        public Dictionary<int, DateTime> Counters { get; set; } = new Dictionary<int, DateTime>();
+
+        public void Start()
+        {
+            StartTime = DateTime.Now;
+        }
+
+        public void CountTime()
+        {
+            CurrentCounter++;
+            Counters.Add(CurrentCounter, DateTime.Now);
+        }
+
+        public int GetTimeAvgBetweenCounters()
+        {
+            var countersSize = Counters.Count;
+            var countersTimeSum = 0;
+            var lastDate = DateTime.MinValue;
+            
+            foreach (var counter in Counters)
+            {
+                if (countersTimeSum == 0)
+                {
+                    countersTimeSum = (StartTime - counter.Value).Seconds;
+                    lastDate = counter.Value;
+                    continue;
+                }
+
+                countersTimeSum += (lastDate - counter.Value).Seconds;
+                lastDate = counter.Value;
+            }
+
+            double timeDiffInMinutes = countersTimeSum / 60;
+            var avg = (int) Math.Ceiling(timeDiffInMinutes / countersSize);
+
+            return avg;
+        }
+    }
+}

--- a/src/Mvp24Hours.Infrastructure.CronJob/Extensions/ScheduledServiceExtensions.cs
+++ b/src/Mvp24Hours.Infrastructure.CronJob/Extensions/ScheduledServiceExtensions.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Mvp24Hours.Infrastructure.CronJob.Interfaces;
+using Mvp24Hours.Infrastructure.CronJob.Services;
+using System;
+
+namespace Mvp24Hours.Infrastructure.CronJob.Extensions
+{
+    public static class ScheduledServiceExtensions
+    {
+        public static IServiceCollection AddCronJob<T>(this IServiceCollection services, Action<IScheduleConfig<T>> options) where T : CronJobService<T>
+        {
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options), @"Please provide Schedule Configurations.");
+            }
+            var config = new ScheduleConfig<T>();
+            options.Invoke(config);
+            services.AddSingleton<IScheduleConfig<T>>(config);
+            services.AddHostedService<T>();
+            return services;
+        }
+    }
+}

--- a/src/Mvp24Hours.Infrastructure.CronJob/Interfaces/IScheduleConfig.cs
+++ b/src/Mvp24Hours.Infrastructure.CronJob/Interfaces/IScheduleConfig.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace Mvp24Hours.Infrastructure.CronJob.Interfaces
+{
+    public interface IScheduleConfig<T>
+    {
+        string CronExpression { get; set; }
+        TimeZoneInfo TimeZoneInfo { get; set; }
+    }
+}

--- a/src/Mvp24Hours.Infrastructure.CronJob/Mvp24Hours.Infrastructure.CronJob.csproj
+++ b/src/Mvp24Hours.Infrastructure.CronJob/Mvp24Hours.Infrastructure.CronJob.csproj
@@ -17,6 +17,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Cronos" Version="0.8.3" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Mvp24Hours.Core\Mvp24Hours.Core.csproj" />
     <ProjectReference Include="..\Mvp24Hours.Infrastructure\Mvp24Hours.Infrastructure.csproj" />
   </ItemGroup>

--- a/src/Mvp24Hours.Infrastructure.CronJob/Mvp24Hours.Infrastructure.CronJob.csproj
+++ b/src/Mvp24Hours.Infrastructure.CronJob/Mvp24Hours.Infrastructure.CronJob.csproj
@@ -1,0 +1,30 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>12.0</LangVersion>
+    <Authors>Kallebe Lins</Authors>
+    <Description>Series architectures for fast product construction.</Description>
+    <Copyright></Copyright>
+    <PackageProjectUrl>https://mvp24hours.dev</PackageProjectUrl>
+    <Company>Kallebe Lins</Company>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <Version>8.2.102</Version>
+    <AssemblyVersion>8.2.10.2</AssemblyVersion>
+    <FileVersion>8.2.10.2</FileVersion>
+    <RepositoryUrl>https://github.com/kallebelins/mvp24hours-dotnet</RepositoryUrl>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Mvp24Hours.Core\Mvp24Hours.Core.csproj" />
+    <ProjectReference Include="..\Mvp24Hours.Infrastructure\Mvp24Hours.Infrastructure.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <SonarQubeSetting Include="sonar.stylecop.projectFilePath">
+      <Value>$(MSBuildProjectFullPath)</Value>
+    </SonarQubeSetting>
+  </ItemGroup>
+
+</Project>

--- a/src/Mvp24Hours.Infrastructure.CronJob/ScheduleConfig.cs
+++ b/src/Mvp24Hours.Infrastructure.CronJob/ScheduleConfig.cs
@@ -1,0 +1,11 @@
+﻿using Mvp24Hours.Infrastructure.CronJob.Interfaces;
+using System;
+
+namespace Mvp24Hours.Infrastructure.CronJob
+{
+    public class ScheduleConfig<T> : IScheduleConfig<T>
+    {
+        public string CronExpression { get; set; }
+        public TimeZoneInfo TimeZoneInfo { get; set; }
+    }
+}

--- a/src/Mvp24Hours.Infrastructure.CronJob/Services/CronJobService.cs
+++ b/src/Mvp24Hours.Infrastructure.CronJob/Services/CronJobService.cs
@@ -1,0 +1,129 @@
+﻿using Cronos;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Mvp24Hours.Infrastructure.CronJob.Interfaces;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+
+namespace Mvp24Hours.Infrastructure.CronJob.Services
+{
+    public abstract class CronJobService<T> : IHostedService, IDisposable
+    {
+        private System.Timers.Timer _timer;
+        private readonly CronExpression _expression;
+        private readonly TimeZoneInfo _timeZoneInfo;
+        private readonly IHostApplicationLifetime _hostApplication;
+        private IServiceScope _serviceScope;
+        private IServiceProvider _serviceProvider;
+
+        protected CronJobService(
+            IScheduleConfig<T> config,
+            IHostApplicationLifetime hostApplication,
+            IServiceProvider serviceProvider)
+        {
+            if (!string.IsNullOrEmpty(config.CronExpression))
+            {
+                _expression = CronExpression.Parse(config.CronExpression);
+            }
+            _timeZoneInfo = config.TimeZoneInfo;
+            _hostApplication = hostApplication;
+            _serviceProvider = serviceProvider;
+        }
+
+        public virtual async Task StartAsync(CancellationToken cancellationToken)
+        {
+            //_logger.LogInformation("::StartAsync");
+            if (_expression != null)
+            {
+                await ScheduleJob(cancellationToken);
+                return;
+            }
+
+            await ExecuteOnce(cancellationToken);
+        }
+
+        protected virtual async Task ExecuteOnce(CancellationToken cancellationToken)
+        {
+            try
+            {
+                //_logger.LogInformation("::ExecuteOnce");
+                //_logger.LogInformation("::Before DoWork");
+                await DoWork(cancellationToken);
+                //_logger.LogInformation("::After DoWork");
+                //_logger.LogInformation("::Shutdown application...");
+            }
+            catch (Exception ex)
+            {
+                //_logger.LogError(ex, "Ocorreu um erro durante o processamento");
+            }
+            finally
+            {
+                _hostApplication.StopApplication();
+            }
+        }
+
+        protected virtual async Task ScheduleJob(CancellationToken cancellationToken)
+        {
+            //_logger.LogInformation("::ScheduleJob");
+            var next = _expression.GetNextOccurrence(DateTimeOffset.Now, _timeZoneInfo);
+            if (next.HasValue)
+            {
+                var delay = next.Value - DateTimeOffset.Now;
+                if (delay.TotalMilliseconds <= 0)
+                {
+                    await ScheduleJob(cancellationToken);
+                }
+                _timer = new System.Timers.Timer(delay.TotalMilliseconds);
+                _timer.Elapsed += async (sender, args) =>
+                {
+                    try
+                    {
+                        ResetServiceProvider(); 
+                        _timer.Dispose();
+                        _timer = null;
+
+                        if (!cancellationToken.IsCancellationRequested)
+                        {
+                            //_logger.LogInformation("::Before DoWork");
+                            await DoWork(cancellationToken);
+                            //_logger.LogInformation("::After DoWork");
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        //_logger.LogError(ex, "Ocorreu um erro durante o processamento");
+                    }
+                    finally
+                    {
+                        if (!cancellationToken.IsCancellationRequested)
+                        {
+                            await ScheduleJob(cancellationToken);
+                        }
+                    }
+                };
+                _timer.Start();
+            }
+            await Task.CompletedTask;
+        }
+
+        public abstract Task DoWork(CancellationToken cancellationToken);
+
+        public virtual async Task StopAsync(CancellationToken cancellationToken)
+        {
+            //_logger.LogInformation("::StopAsync");
+            _timer?.Stop();
+            await Task.CompletedTask;
+        }
+
+        public virtual void Dispose()
+        {
+            _logger.LogInformation("::Dispose");
+            _timer?.Dispose();
+        }
+    
+        private void ResetServiceProvider() => _serviceProvider = _serviceProvider.CreateScope().ServiceProvider;
+    }
+}

--- a/src/Mvp24Hours.Infrastructure.CronJob/Services/CronJobService.cs
+++ b/src/Mvp24Hours.Infrastructure.CronJob/Services/CronJobService.cs
@@ -17,7 +17,7 @@ namespace Mvp24Hours.Infrastructure.CronJob.Services
         private readonly CronExpression _expression;
         private readonly TimeZoneInfo _timeZoneInfo;
         private readonly IHostApplicationLifetime _hostApplication;
-        private IServiceProvider _serviceProvider;
+        public IServiceProvider _serviceProvider;
 
         protected CronJobService(
             IScheduleConfig<T> config,

--- a/src/Mvp24Hours.sln
+++ b/src/Mvp24Hours.sln
@@ -42,7 +42,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Mvp24Hours.Patterns.Test", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Mvp24Hours.WebAPI.Test", "Tests\Mvp24Hours.WebAPI.Test\Mvp24Hours.WebAPI.Test.csproj", "{5CE4DA63-7E5C-4D61-BD34-C57E33AB8DC1}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mvp24Hours.Infrastructure.CronJob", "Mvp24Hours.Infrastructure.CronJob\Mvp24Hours.Infrastructure.CronJob.csproj", "{C8DDFCB6-2173-456B-BE6F-00DCCD021B2B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Mvp24Hours.Infrastructure.CronJob", "Mvp24Hours.Infrastructure.CronJob\Mvp24Hours.Infrastructure.CronJob.csproj", "{C8DDFCB6-2173-456B-BE6F-00DCCD021B2B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mvp24Hours.Application.CronJob.Test", "Mvp24Hours.Application.CronJob.Test\Mvp24Hours.Application.CronJob.Test.csproj", "{AD87C44C-A74B-4A8B-A5ED-5B4D7EF38E3F}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -130,6 +132,10 @@ Global
 		{C8DDFCB6-2173-456B-BE6F-00DCCD021B2B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C8DDFCB6-2173-456B-BE6F-00DCCD021B2B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C8DDFCB6-2173-456B-BE6F-00DCCD021B2B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AD87C44C-A74B-4A8B-A5ED-5B4D7EF38E3F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AD87C44C-A74B-4A8B-A5ED-5B4D7EF38E3F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AD87C44C-A74B-4A8B-A5ED-5B4D7EF38E3F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AD87C44C-A74B-4A8B-A5ED-5B4D7EF38E3F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -144,6 +150,7 @@ Global
 		{6BDCA772-4E93-46CE-B117-A75B70446ED4} = {B19FC8A6-B1BB-4E0B-8150-E4CC0C55D05C}
 		{E581E2B0-4DD2-43D4-AEFE-B190CFAA2193} = {B19FC8A6-B1BB-4E0B-8150-E4CC0C55D05C}
 		{5CE4DA63-7E5C-4D61-BD34-C57E33AB8DC1} = {B19FC8A6-B1BB-4E0B-8150-E4CC0C55D05C}
+		{AD87C44C-A74B-4A8B-A5ED-5B4D7EF38E3F} = {B19FC8A6-B1BB-4E0B-8150-E4CC0C55D05C}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {1CAAF17E-39C7-40C6-A4BE-09BC5EE90B95}

--- a/src/Mvp24Hours.sln
+++ b/src/Mvp24Hours.sln
@@ -42,6 +42,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Mvp24Hours.Patterns.Test", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Mvp24Hours.WebAPI.Test", "Tests\Mvp24Hours.WebAPI.Test\Mvp24Hours.WebAPI.Test.csproj", "{5CE4DA63-7E5C-4D61-BD34-C57E33AB8DC1}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mvp24Hours.Infrastructure.CronJob", "Mvp24Hours.Infrastructure.CronJob\Mvp24Hours.Infrastructure.CronJob.csproj", "{C8DDFCB6-2173-456B-BE6F-00DCCD021B2B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -124,6 +126,10 @@ Global
 		{5CE4DA63-7E5C-4D61-BD34-C57E33AB8DC1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5CE4DA63-7E5C-4D61-BD34-C57E33AB8DC1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5CE4DA63-7E5C-4D61-BD34-C57E33AB8DC1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C8DDFCB6-2173-456B-BE6F-00DCCD021B2B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C8DDFCB6-2173-456B-BE6F-00DCCD021B2B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C8DDFCB6-2173-456B-BE6F-00DCCD021B2B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C8DDFCB6-2173-456B-BE6F-00DCCD021B2B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
In this PR I'm submitting a solution to address issue #2. This solution makes it possible to create jobs to run in the background on a scheduled basis. We can schedule jobs to run at certain times, e.g. every minute, every hour and so on. To configure this, we must the `UNIX cron` format, like `* * * * *`.

## CronJob Service
```csharp
class MyCronJob : CronJobService<MyCronJob>
{
    public MyCronJob(
        IScheduleConfig<CustomerCronJob> config, 
        IHostApplicationLifetime hostApplication, 
        IServiceProvider serviceProvider) : base(config, hostApplication, serviceProvider)
    { }

    public override Task DoWork(CancellationToken cancellationToken)
    {
       //put the logic here
    }
}
```

## Settings
```csharp
...
services.AddCronJob<MyCronJob>(options => 
{
    TimeZoneInfo = TimeZoneInfo.Utc,
    CronExpression = "* * * * *"
})
```

In the exemple above, the Job will be executed `every minute`. 

@kallebelins  could you review, please ?