### PR TITLE
Adicionando uma propriedade que permite que o pipeline propague a exc…

### DIFF
--- a/src/Mvp24Hours.Core/Contract/Infrastructure/Pipe/Async/IPipelineAsync.cs
+++ b/src/Mvp24Hours.Core/Contract/Infrastructure/Pipe/Async/IPipelineAsync.cs
@@ -27,6 +27,10 @@ namespace Mvp24Hours.Core.Contract.Infrastructure.Pipe
         /// </summary>
         bool ForceRollbackOnFalure { get; set; }
         /// <summary>
+        /// Force the pipeline to call rollback operations for each operations executed previously
+        /// </summary>
+        bool AllowPropagateException { get; set; }
+        /// <summary>
         /// Get message package
         /// </summary>
         /// <returns></returns>

--- a/src/Mvp24Hours.Core/Contract/Infrastructure/Pipe/IPipeline.cs
+++ b/src/Mvp24Hours.Core/Contract/Infrastructure/Pipe/IPipeline.cs
@@ -22,6 +22,14 @@ namespace Mvp24Hours.Core.Contract.Infrastructure.Pipe
     public interface IPipeline
     {
         /// <summary>
+        /// Force the pipeline to call rollback operations for each operations executed previously
+        /// </summary>
+        bool ForceRollbackOnFalure { get; set; }
+        /// <summary>
+        /// Force the pipeline to call rollback operations for each operations executed previously
+        /// </summary>
+        bool AllowPropagateException { get; set; }
+        /// <summary>
         /// Get message package
         /// </summary>
         /// <returns></returns>

--- a/src/Mvp24Hours.Infrastructure.Pipe/PipelineBase.cs
+++ b/src/Mvp24Hours.Infrastructure.Pipe/PipelineBase.cs
@@ -27,6 +27,7 @@ namespace Mvp24Hours.Infrastructure.Pipe
 
         #region [ Fields / Properties ]
         protected bool IsBreakOnFail { get; set; }
+        public bool AllowPropagateException { get; set; }
         public bool ForceRollbackOnFalure { get; set; }
         protected IPipelineMessage Message { get; set; }        
         #endregion

--- a/src/Tests/Mvp24Hours.Application.Pipe.Test/PipelineAsyncTest.cs
+++ b/src/Tests/Mvp24Hours.Application.Pipe.Test/PipelineAsyncTest.cs
@@ -8,6 +8,7 @@ using Mvp24Hours.Application.Pipe.Test.Rollbacks;
 using Mvp24Hours.Core.Enums.Infrastructure;
 using Mvp24Hours.Extensions;
 using Mvp24Hours.Infrastructure.Pipe;
+using System;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using Xunit;
@@ -621,6 +622,60 @@ namespace Mvp24Hours.Application.Pipe.Test
             Assert.False(resultRollbackStep1);
             Assert.False(resultRollbackStep2);
             Assert.False(resultRollbackStep3);            
+        }
+
+        [Fact, Priority(14)]
+        public async Task PipelineWithWithAllowPropagateException()
+        {
+            // arrange
+            var pipeline = new PipelineAsync() { AllowPropagateException = true };
+            var exception = default(Exception);
+
+            // act
+            pipeline.Add<RollbackOperationTestAsyncStep1>();
+            pipeline.Add<RollbackOperationTestAsyncStep2>();
+            pipeline.Add<RollbackOperationTestAsyncStep3>();
+
+            try
+            {
+                // operations
+                await pipeline.ExecuteAsync();
+            }
+            catch (Exception ex)
+            {
+                exception = ex;
+            }
+
+            // assert
+            Assert.NotNull(exception);
+            Assert.Equal("My Exception 123", exception.Message);
+            Assert.Equal(typeof(InvalidOperationException), exception.GetType());
+        }
+
+        [Fact, Priority(15)]
+        public async Task PipelineWithWithoutAllowPropagateException()
+        {
+            // arrange
+            var pipeline = new PipelineAsync(); //AllowPropagateException = false
+            var exception = default(Exception);
+
+            // act
+            pipeline.Add<RollbackOperationTestAsyncStep1>();
+            pipeline.Add<RollbackOperationTestAsyncStep2>();
+            pipeline.Add<RollbackOperationTestAsyncStep3>();
+
+            try
+            {
+                // operations
+                await pipeline.ExecuteAsync();
+            }
+            catch (Exception ex)
+            {
+                exception = ex;
+            }
+
+            // assert
+            Assert.Null(exception);
         }
     }
 }

--- a/src/Tests/Mvp24Hours.Application.Pipe.Test/PipelineTest.cs
+++ b/src/Tests/Mvp24Hours.Application.Pipe.Test/PipelineTest.cs
@@ -9,6 +9,7 @@ using Mvp24Hours.Core.Enums;
 using Mvp24Hours.Core.Enums.Infrastructure;
 using Mvp24Hours.Extensions;
 using Mvp24Hours.Infrastructure.Pipe;
+using System;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using Xunit;
@@ -644,6 +645,60 @@ namespace Mvp24Hours.Application.Pipe.Test
             Assert.False(resultRollbackStep1);
             Assert.False(resultRollbackStep2);
             Assert.False(resultRollbackStep3);
+        }
+
+        [Fact, Priority(15)]
+        public void PipelineWithWithAllowPropagateException()
+        {
+            // arrange
+            var pipeline = new Pipeline() { AllowPropagateException = true };
+            var exception = default(Exception);
+
+            // act
+            pipeline.Add<RollbackOperationTestStep1>();
+            pipeline.Add<RollbackOperationTestStep2>();
+            pipeline.Add<RollbackOperationTestStep3>();
+
+            try
+            {
+                // operations
+                pipeline.Execute();
+            }
+            catch (Exception ex)
+            {
+                exception = ex;
+            }
+
+            // assert
+            Assert.NotNull(exception);
+            Assert.Equal("My Exception 123", exception.Message);
+            Assert.Equal(typeof(InvalidOperationException), exception.GetType());
+        }
+
+        [Fact, Priority(16)]
+        public void PipelineWithWithoutAllowPropagateException()
+        {
+            // arrange
+            var pipeline = new Pipeline(); //AllowPropagateException = false
+            var exception = default(Exception);
+
+            // act
+            pipeline.Add<RollbackOperationTestStep1>();
+            pipeline.Add<RollbackOperationTestStep2>();
+            pipeline.Add<RollbackOperationTestStep3>();
+
+            try
+            {
+                // operations
+                pipeline.Execute();
+            }
+            catch (Exception ex)
+            {
+                exception = ex;
+            }
+
+            // assert
+            Assert.Null(exception);
         }
     }
 }

--- a/src/Tests/Mvp24Hours.Application.Pipe.Test/Rollbacks/RollbackOperationTestAsyncStep3.cs
+++ b/src/Tests/Mvp24Hours.Application.Pipe.Test/Rollbacks/RollbackOperationTestAsyncStep3.cs
@@ -9,7 +9,7 @@ namespace Mvp24Hours.Application.Pipe.Test.Rollbacks
         public override async Task ExecuteAsync(IPipelineMessage input)
         {
             input.AddContent("key-test-step3", 3);
-            throw new System.Exception();
+            throw new System.InvalidOperationException("My Exception 123");
         }
 
         public override async Task RollbackAsync(IPipelineMessage input)

--- a/src/Tests/Mvp24Hours.Application.Pipe.Test/Rollbacks/RollbackOperationTestStep3.cs
+++ b/src/Tests/Mvp24Hours.Application.Pipe.Test/Rollbacks/RollbackOperationTestStep3.cs
@@ -8,7 +8,7 @@ namespace Mvp24Hours.Application.Pipe.Test.Rollbacks
         public override void Execute(IPipelineMessage input)
         {
             input.AddContent("key-test-step3", 3);
-            throw new System.Exception();
+            throw new System.InvalidOperationException("My Exception 123");
         }
 
         public override void Rollback(IPipelineMessage input)


### PR DESCRIPTION
…eption para o chamador.

Essa propriedade não impede que o rollback seja acionado e nem outras funções de controle de erro. A exception só será lançada por último após todas as execuções