### PR TITLE
dynamic content property in pipeline message.

### DIFF
--- a/src/Mvp24Hours.Core/Contract/Infrastructure/Pipe/IPipelineMessage.cs
+++ b/src/Mvp24Hours.Core/Contract/Infrastructure/Pipe/IPipelineMessage.cs
@@ -25,7 +25,7 @@ namespace Mvp24Hours.Core.Contract.Infrastructure.Pipe
         /// <summary>
         /// Allow access to a content by a dynamic object
         /// </summary>
-        dynamic NonNullableContents { get; }
+        dynamic DynamicContents { get; }
         /// <summary>
         /// List of feedback messages
         /// </summary>

--- a/src/Mvp24Hours.Core/Contract/Infrastructure/Pipe/IPipelineMessage.cs
+++ b/src/Mvp24Hours.Core/Contract/Infrastructure/Pipe/IPipelineMessage.cs
@@ -23,6 +23,10 @@ namespace Mvp24Hours.Core.Contract.Infrastructure.Pipe
         /// </summary>
         bool IsFaulty { get; }
         /// <summary>
+        /// Allow access to a content by a dynamic object
+        /// </summary>
+        dynamic NonNullableContents { get; }
+        /// <summary>
         /// List of feedback messages
         /// </summary>
         IList<IMessageResult> Messages { get; }

--- a/src/Mvp24Hours.Infrastructure.Pipe/CustomDynamicObject.cs
+++ b/src/Mvp24Hours.Infrastructure.Pipe/CustomDynamicObject.cs
@@ -1,0 +1,45 @@
+﻿using Mvp24Hours.Core.Contract.Infrastructure.Pipe;
+using System;
+using System.Dynamic;
+
+namespace Mvp24Hours.Infrastructure.Pipe
+{
+    public class CustomDynamicObject : DynamicObject
+    {
+        private readonly IPipelineMessage _pipelineMessage;
+
+        public CustomDynamicObject(IPipelineMessage pipelineMessage)
+        {
+            _pipelineMessage = pipelineMessage;
+        }
+
+        public override bool TryGetMember(GetMemberBinder binder, out object result)
+        {
+            if (_pipelineMessage.HasContent(binder.Name))
+            {
+                result = _pipelineMessage.GetContent<object>(binder.Name);
+
+                if (result == null)
+                    throw new ArgumentNullException($"{binder.Name} property is null in pipeline message");
+
+                return true;
+            }
+
+            throw new ArgumentOutOfRangeException($"{binder.Name} property does not exist in pipeline message");
+        }
+
+        public override bool TrySetMember(SetMemberBinder binder, object value)
+        {
+            if (value == null)
+                throw new ArgumentNullException($"{binder.Name} property cannot be null in pipeline message");
+
+            _pipelineMessage.AddContent(binder.Name, value);
+            return true;
+        }
+
+        public override string ToString()
+        {
+            return base.ToString();
+        }
+    }
+}

--- a/src/Mvp24Hours.Infrastructure.Pipe/DynamicContents.cs
+++ b/src/Mvp24Hours.Infrastructure.Pipe/DynamicContents.cs
@@ -4,11 +4,11 @@ using System.Dynamic;
 
 namespace Mvp24Hours.Infrastructure.Pipe
 {
-    public class CustomDynamicObject : DynamicObject
+    public class DynamicContents : DynamicObject
     {
         private readonly IPipelineMessage _pipelineMessage;
 
-        public CustomDynamicObject(IPipelineMessage pipelineMessage)
+        public DynamicContents(IPipelineMessage pipelineMessage)
         {
             _pipelineMessage = pipelineMessage;
         }

--- a/src/Mvp24Hours.Infrastructure.Pipe/PipelineMessage.cs
+++ b/src/Mvp24Hours.Infrastructure.Pipe/PipelineMessage.cs
@@ -37,7 +37,7 @@ namespace Mvp24Hours.Infrastructure.Pipe
         {
             this._contents = [];
             this.Token = token;
-            this.DynamicContents = new CustomDynamicObject(this);
+            this.DynamicContents = new DynamicContents(this);
 
             if (args?.Length > 0)
             {

--- a/src/Mvp24Hours.Infrastructure.Pipe/PipelineMessage.cs
+++ b/src/Mvp24Hours.Infrastructure.Pipe/PipelineMessage.cs
@@ -37,7 +37,7 @@ namespace Mvp24Hours.Infrastructure.Pipe
         {
             this._contents = [];
             this.Token = token;
-            this.NonNullableContents = new CustomDynamicObject(this);
+            this.DynamicContents = new CustomDynamicObject(this);
 
             if (args?.Length > 0)
             {
@@ -73,7 +73,7 @@ namespace Mvp24Hours.Infrastructure.Pipe
         }
         public string Token { get; private set; }
         public bool IsLocked { get; private set; }
-        public dynamic NonNullableContents { get; private set; }
+        public dynamic DynamicContents { get; private set; }
         #endregion
 
         #region [ Methods ]

--- a/src/Mvp24Hours.Infrastructure.Pipe/PipelineMessage.cs
+++ b/src/Mvp24Hours.Infrastructure.Pipe/PipelineMessage.cs
@@ -37,6 +37,7 @@ namespace Mvp24Hours.Infrastructure.Pipe
         {
             this._contents = [];
             this.Token = token;
+            this.NonNullableContents = new CustomDynamicObject(this);
 
             if (args?.Length > 0)
             {
@@ -72,6 +73,7 @@ namespace Mvp24Hours.Infrastructure.Pipe
         }
         public string Token { get; private set; }
         public bool IsLocked { get; private set; }
+        public dynamic NonNullableContents { get; private set; }
         #endregion
 
         #region [ Methods ]

--- a/src/Tests/Mvp24Hours.Application.Pipe.Test/Mvp24Hours.Application.Pipe.Test.csproj
+++ b/src/Tests/Mvp24Hours.Application.Pipe.Test/Mvp24Hours.Application.Pipe.Test.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-
+    <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Tests/Mvp24Hours.Application.Pipe.Test/PipelineAsyncTest.cs
+++ b/src/Tests/Mvp24Hours.Application.Pipe.Test/PipelineAsyncTest.cs
@@ -5,6 +5,7 @@
 //=====================================================================================
 using Mvp24Hours.Application.Pipe.Test.Operations;
 using Mvp24Hours.Application.Pipe.Test.Rollbacks;
+using Mvp24Hours.Core.Contract.Infrastructure.Pipe;
 using Mvp24Hours.Core.Enums.Infrastructure;
 using Mvp24Hours.Extensions;
 using Mvp24Hours.Infrastructure.Pipe;
@@ -676,6 +677,6 @@ namespace Mvp24Hours.Application.Pipe.Test
 
             // assert
             Assert.Null(exception);
-        }
+        }        
     }
 }

--- a/src/Tests/Mvp24Hours.Application.Pipe.Test/PipelineTest.cs
+++ b/src/Tests/Mvp24Hours.Application.Pipe.Test/PipelineTest.cs
@@ -710,7 +710,7 @@ namespace Mvp24Hours.Application.Pipe.Test
             IPipelineMessage input = new PipelineMessage();
 
             // operations
-            input.DynamicContents.Person = new Person { Name = "John Smith", CC = new CC { Number = "4532849103927456", CVV = "435", ExpirationDate = "11/32" } }; ;
+            input.DynamicContents.Person = new Person { Name = "John Smith", CC = new CC { Number = "4532849103927456", CVV = "435", ExpirationDate = "11/32" } };
             input.AddContent("person_name", input.DynamicContents.Person.Name);
             input.AddContent("person_CC_Number", input.DynamicContents.Person.CC.Number);
             input.AddContent("person_CC_CVV", input.DynamicContents.Person.CC.CVV);

--- a/src/Tests/Mvp24Hours.Application.Pipe.Test/PipelineTest.cs
+++ b/src/Tests/Mvp24Hours.Application.Pipe.Test/PipelineTest.cs
@@ -710,31 +710,31 @@ namespace Mvp24Hours.Application.Pipe.Test
             IPipelineMessage input = new PipelineMessage();
 
             // operations
-            input.NonNullableContents.Person = new Person { Name = "John Smith", CC = new CC { Number = "4532849103927456", CVV = "435", ExpirationDate = "11/32" } }; ;
-            input.AddContent("person_name", input.NonNullableContents.Person.Name);
-            input.AddContent("person_CC_Number", input.NonNullableContents.Person.CC.Number);
-            input.AddContent("person_CC_CVV", input.NonNullableContents.Person.CC.CVV);
-            input.AddContent("person_CC_ExpirationDate", input.NonNullableContents.Person.CC.ExpirationDate);
-            input.AddContent("person_CC_ExpirationDate", input.NonNullableContents.Person.CC.ExpirationDate);
+            input.DynamicContents.Person = new Person { Name = "John Smith", CC = new CC { Number = "4532849103927456", CVV = "435", ExpirationDate = "11/32" } }; ;
+            input.AddContent("person_name", input.DynamicContents.Person.Name);
+            input.AddContent("person_CC_Number", input.DynamicContents.Person.CC.Number);
+            input.AddContent("person_CC_CVV", input.DynamicContents.Person.CC.CVV);
+            input.AddContent("person_CC_ExpirationDate", input.DynamicContents.Person.CC.ExpirationDate);
+            input.AddContent("person_CC_ExpirationDate", input.DynamicContents.Person.CC.ExpirationDate);
 
             // assert
-            Assert.Equal(input.NonNullableContents.Person.Name, "John Smith");
-            Assert.Equal(input.NonNullableContents.Person.CC.Number, "4532849103927456");
-            Assert.Equal(input.NonNullableContents.Person.CC.CVV, "435");
-            Assert.Equal(input.NonNullableContents.Person.CC.ExpirationDate, "11/32");
+            Assert.Equal(input.DynamicContents.Person.Name, "John Smith");
+            Assert.Equal(input.DynamicContents.Person.CC.Number, "4532849103927456");
+            Assert.Equal(input.DynamicContents.Person.CC.CVV, "435");
+            Assert.Equal(input.DynamicContents.Person.CC.ExpirationDate, "11/32");
 
-            Assert.Equal(input.NonNullableContents.Person.Name, input.GetContent<string>("person_name"));
-            Assert.Equal(input.NonNullableContents.Person.CC.Number, input.GetContent<string>("person_CC_Number"));
-            Assert.Equal(input.NonNullableContents.Person.CC.CVV, input.GetContent<string>("person_CC_CVV"));
-            Assert.Equal(input.NonNullableContents.Person.CC.ExpirationDate, input.GetContent<string>("person_CC_ExpirationDate"));
+            Assert.Equal(input.DynamicContents.Person.Name, input.GetContent<string>("person_name"));
+            Assert.Equal(input.DynamicContents.Person.CC.Number, input.GetContent<string>("person_CC_Number"));
+            Assert.Equal(input.DynamicContents.Person.CC.CVV, input.GetContent<string>("person_CC_CVV"));
+            Assert.Equal(input.DynamicContents.Person.CC.ExpirationDate, input.GetContent<string>("person_CC_ExpirationDate"));
 
-            Assert.Equal(input.NonNullableContents.person_name, input.GetContent<string>("person_name"));
-            Assert.Equal(input.NonNullableContents.person_CC_Number, input.GetContent<string>("person_CC_Number"));
-            Assert.Equal(input.NonNullableContents.person_CC_CVV, input.GetContent<string>("person_CC_CVV"));
-            Assert.Equal(input.NonNullableContents.person_CC_ExpirationDate, input.GetContent<string>("person_CC_ExpirationDate"));
+            Assert.Equal(input.DynamicContents.person_name, input.GetContent<string>("person_name"));
+            Assert.Equal(input.DynamicContents.person_CC_Number, input.GetContent<string>("person_CC_Number"));
+            Assert.Equal(input.DynamicContents.person_CC_CVV, input.GetContent<string>("person_CC_CVV"));
+            Assert.Equal(input.DynamicContents.person_CC_ExpirationDate, input.GetContent<string>("person_CC_ExpirationDate"));
 
             var personExpected = input.GetContent<Person>("Person");
-            var personActual = input.NonNullableContents.Person;
+            var personActual = input.DynamicContents.Person;
 
             Assert.Equal(personExpected.Name, personActual.Name);
             Assert.Equal(personExpected.CC.Number, personActual.CC.Number);
@@ -753,7 +753,7 @@ namespace Mvp24Hours.Application.Pipe.Test
             // operations
             try
             {
-                input.NonNullableContents.Person = default(Person);
+                input.DynamicContents.Person = default(Person);
             }
             catch (ArgumentNullException ex)
             {
@@ -762,7 +762,7 @@ namespace Mvp24Hours.Application.Pipe.Test
 
             try
             {
-                var person = input.NonNullableContents.PersonNotExist;
+                var person = input.DynamicContents.PersonNotExist;
             }
             catch (ArgumentOutOfRangeException ex)
             {

--- a/src/Tests/Mvp24Hours.Application.Pipe.Test/PipelineTest.cs
+++ b/src/Tests/Mvp24Hours.Application.Pipe.Test/PipelineTest.cs
@@ -771,7 +771,7 @@ namespace Mvp24Hours.Application.Pipe.Test
 
             // assert
             Assert.NotNull(setExceptionNull);
-            Assert.NotNull(setExceptionNull);
+            Assert.NotNull(getExceptionOutOfRange);
         }
 
         class Person


### PR DESCRIPTION
Now it's possible to access the same contents field using a dynamic property called "DynamicContents".

This new property does NOT allow nullable values throwing ArgumentNullException in set operation and ArgumentOutOfRangeException in get operation in not existing case

It's not necessary to storage string keys for AddContent and GetContent anymore